### PR TITLE
Add support for single Fallback Font

### DIFF
--- a/cmd/neoray/context_menu.go
+++ b/cmd/neoray/context_menu.go
@@ -119,6 +119,11 @@ func (menu *ContextMenu) SetFontKit(kit *fontkit.FontKit) {
 	MarkForceDraw()
 }
 
+func (menu *ContextMenu) SetFallbackFontKit(kit *fontkit.FontKit) {
+	menu.renderer.SetFallbackFontKit(kit)
+	MarkForceDraw()
+}
+
 func (menu *ContextMenu) SetFontSize(size float64) {
 	menu.renderer.SetFontSize(size, Editor.window.DPI())
 	MarkForceDraw()

--- a/cmd/neoray/grid.go
+++ b/cmd/neoray/grid.go
@@ -138,6 +138,10 @@ func (grid *Grid) SetFontKit(kit *fontkit.FontKit) {
 	grid.renderer.SetFontKit(kit)
 }
 
+func (grid *Grid) SetFontFallbackKit(kit *fontkit.FontKit) {
+	grid.renderer.SetFallbackFontKit(kit)
+}
+
 func (grid *Grid) SetFontSize(fontSize, dpi float64) {
 	grid.renderer.SetFontSize(fontSize, dpi)
 }

--- a/cmd/neoray/grid_manager.go
+++ b/cmd/neoray/grid_manager.go
@@ -16,6 +16,7 @@ type GridManager struct {
 	// These are used for creating new grids
 	totalGridsCreated int              // total number of grids created (including deleted ones)
 	kit               *fontkit.FontKit // last globally set font kit
+	fallbackKit       *fontkit.FontKit // last globally set font fallback
 	fontSize          float64          // last globally set font size
 	// style information
 	attributes map[int]HighlightAttribute
@@ -46,6 +47,24 @@ func (manager *GridManager) SetGridFontKit(id int, kit *fontkit.FontKit) {
 		if grid != nil {
 			prevSize := grid.Size()
 			grid.SetFontKit(kit)
+			manager.CheckGridSize(grid, prevSize)
+		}
+	}
+	MarkForceDraw()
+}
+
+func (manager *GridManager) SetGridFallbackFontKit(id int, kit *fontkit.FontKit) {
+	if id == 1 {
+		for _, grid := range manager.grids {
+			grid.SetFontFallbackKit(kit)
+		}
+		manager.fallbackKit = kit
+		manager.CheckDefaultGridSize()
+	} else {
+		grid := manager.Grid(id)
+		if grid != nil {
+			prevSize := grid.Size()
+			grid.SetFontFallbackKit(kit)
 			manager.CheckGridSize(grid, prevSize)
 		}
 	}

--- a/cmd/neoray/grid_renderer.go
+++ b/cmd/neoray/grid_renderer.go
@@ -31,6 +31,11 @@ func (renderer *GridRenderer) SetFontKit(kit *fontkit.FontKit) {
 	renderer.UpdatePositions()
 }
 
+func (renderer *GridRenderer) SetFallbackFontKit(kit *fontkit.FontKit) {
+	renderer.atlas.SetFallbackFontKit(kit)
+	renderer.UpdatePositions()
+}
+
 func (renderer *GridRenderer) FontSize() float64 {
 	return renderer.atlas.FontSize()
 }

--- a/cmd/neoray/style.go
+++ b/cmd/neoray/style.go
@@ -43,7 +43,12 @@ func (options *UIOptions) setGuiFont(guifont string) {
 	guifont = strings.ReplaceAll(guifont, "_", " ")
 	// parse font options
 	fontOptions := strings.Split(guifont, ":")
-	name := fontOptions[0]
+	fontNames := strings.Split(fontOptions[0], ",")
+	name := fontNames[0]
+	fallbackName := ""
+	if len(fontNames) >= 2 {
+		fallbackName = fontNames[1]
+	}
 	for _, opt := range fontOptions[1:] {
 		if len(opt) > 1 && opt[0] == 'h' {
 			// Font size
@@ -80,6 +85,30 @@ func (options *UIOptions) setGuiFont(guifont string) {
 			// Set fonts
 			Editor.gridManager.SetGridFontKit(1, kit)
 			Editor.contextMenu.SetFontKit(kit)
+		}
+	}
+	if fallbackName != "" {
+		logger.Log(logger.TRACE, "Loading fallback font", fallbackName)
+		kit, err := fontkit.CreateKit(fallbackName)
+		if err != nil {
+			Editor.nvim.EchoError("Fallback font %s not found", fallbackName)
+		} else {
+			// Log some info
+			if kit.Regular() != nil {
+				logger.Log(logger.TRACE, "Regular:", kit.Regular().FilePath())
+			}
+			if kit.Bold() != nil {
+				logger.Log(logger.TRACE, "Bold:", kit.Bold().FilePath())
+			}
+			if kit.Italic() != nil {
+				logger.Log(logger.TRACE, "Italic:", kit.Italic().FilePath())
+			}
+			if kit.BoldItalic() != nil {
+				logger.Log(logger.TRACE, "BoldItalic:", kit.BoldItalic().FilePath())
+			}
+			// Set fallback font
+			Editor.gridManager.SetGridFallbackFontKit(1, kit)
+			Editor.contextMenu.SetFallbackFontKit(kit)
 		}
 	}
 	// Always set font size to default if user not set

--- a/pkg/fontfinder/fontfinder.go
+++ b/pkg/fontfinder/fontfinder.go
@@ -37,6 +37,7 @@ var (
 	// List of installed system fonts.
 	systemFontList      []*sysfont.Font
 	systemFontListGuard sync.Mutex
+	systemFontInitDone  bool
 
 	// Add more if you know any other filename used in
 	// font names. All characters must be lowercase.
@@ -57,10 +58,13 @@ func init() {
 			Extensions: []string{".ttf", ".otf"},
 		})
 		systemFontList = finder.List()
+		systemFontInitDone = true
 	}()
 }
 
 func List() []*sysfont.Font {
+	for !systemFontInitDone {
+	}
 	systemFontListGuard.Lock()
 	defer systemFontListGuard.Unlock()
 	return systemFontList
@@ -153,8 +157,9 @@ func sortFileNameLen(fonts *[]fontSearchInfo) {
 
 // Splits string to words according to delimiters and casing.
 // Example:
-//  This:           "HelloWorld_from-Turkey"
-//  Turns to this:  [Hello, World, from, Turkey]
+//
+//	This:           "HelloWorld_from-Turkey"
+//	Turns to this:  [Hello, World, from, Turkey]
 func splitWords(str string) []string {
 	// CamelCase pascalCase and "-_ "
 	arr := []string{}

--- a/pkg/fontfinder/fontfinder.go
+++ b/pkg/fontfinder/fontfinder.go
@@ -37,7 +37,6 @@ var (
 	// List of installed system fonts.
 	systemFontList      []*sysfont.Font
 	systemFontListGuard sync.Mutex
-	systemFontInitDone  bool
 
 	// Add more if you know any other filename used in
 	// font names. All characters must be lowercase.
@@ -51,20 +50,17 @@ func init() {
 	// Because of this we are doing this in initilization and in another
 	// goroutine. Updates systemFontListReady value to true when finished.
 	// And Find() will wait for this to be done only for first time.
+	systemFontListGuard.Lock()
 	go func() {
-		systemFontListGuard.Lock()
 		defer systemFontListGuard.Unlock()
 		finder := sysfont.NewFinder(&sysfont.FinderOpts{
 			Extensions: []string{".ttf", ".otf"},
 		})
 		systemFontList = finder.List()
-		systemFontInitDone = true
 	}()
 }
 
 func List() []*sysfont.Font {
-	for !systemFontInitDone {
-	}
 	systemFontListGuard.Lock()
 	defer systemFontListGuard.Unlock()
 	return systemFontList

--- a/pkg/opengl/atlas.go
+++ b/pkg/opengl/atlas.go
@@ -16,6 +16,7 @@ const (
 
 type Atlas struct {
 	kit             *fontkit.FontKit
+	fallback 				*fontkit.FontKit
 	fontSize, dpi   float64
 	useBoxDrawing   bool
 	useBlockDrawing bool
@@ -73,6 +74,18 @@ func (atlas *Atlas) SetFontKit(kit *fontkit.FontKit) {
 	atlas.kit = kit
 	atlas.Reset()
 }
+
+func (atlas *Atlas) FallbackFontKit() *fontkit.FontKit {
+	if atlas.fallback != nil {
+		return atlas.fallback
+	}
+	return fontkit.Default()
+}
+
+func (atlas *Atlas) SetFallbackFontKit(kit *fontkit.FontKit) {
+	atlas.fallback = kit
+}
+
 
 func (atlas *Atlas) FontSize() float64 {
 	return atlas.fontSize
@@ -168,6 +181,12 @@ func (atlas *Atlas) suitableFont(char rune, bold, italic bool) (*fontkit.Font, b
 	}
 	if atlas.FontKit().DefaultFont().ContainsGlyph(char) {
 		return atlas.FontKit().DefaultFont(), true
+	}
+	if atlas.FallbackFontKit().SuitableFont(bold ,italic).ContainsGlyph(char) {
+		return atlas.FallbackFontKit().SuitableFont(bold, italic), true
+	}
+	if atlas.FallbackFontKit().DefaultFont().ContainsGlyph(char) {
+		return atlas.FallbackFontKit().DefaultFont(), true
 	}
 	if fontkit.Default().SuitableFont(bold, italic).ContainsGlyph(char) {
 		return fontkit.Default().SuitableFont(bold, italic), true

--- a/pkg/opengl/atlas.go
+++ b/pkg/opengl/atlas.go
@@ -16,7 +16,7 @@ const (
 
 type Atlas struct {
 	kit             *fontkit.FontKit
-	fallback 				*fontkit.FontKit
+	fallback        *fontkit.FontKit
 	fontSize, dpi   float64
 	useBoxDrawing   bool
 	useBlockDrawing bool
@@ -85,7 +85,6 @@ func (atlas *Atlas) FallbackFontKit() *fontkit.FontKit {
 func (atlas *Atlas) SetFallbackFontKit(kit *fontkit.FontKit) {
 	atlas.fallback = kit
 }
-
 
 func (atlas *Atlas) FontSize() float64 {
 	return atlas.fontSize
@@ -182,7 +181,7 @@ func (atlas *Atlas) suitableFont(char rune, bold, italic bool) (*fontkit.Font, b
 	if atlas.FontKit().DefaultFont().ContainsGlyph(char) {
 		return atlas.FontKit().DefaultFont(), true
 	}
-	if atlas.FallbackFontKit().SuitableFont(bold ,italic).ContainsGlyph(char) {
+	if atlas.FallbackFontKit().SuitableFont(bold, italic).ContainsGlyph(char) {
 		return atlas.FallbackFontKit().SuitableFont(bold, italic), true
 	}
 	if atlas.FallbackFontKit().DefaultFont().ContainsGlyph(char) {


### PR DESCRIPTION
I have added support for a single fallback font which can be provided in the `guifont` option with comma seperation.
I needed this as even though the comments in the code suggest the default Font should have Nerd Symbols they were not rendered for me and this way I can provide the Nerd Symbols Font simply as fallback.

So far I have not implemented multiple fallbacks as I think this just increases memory usage and is hardly ever a usecase but if needed I can change it to also support an arbitrary number of fallback fonts.

Also feel free to just reject this PR as I haven't asked beforehand and it simply might not fit your vision.

If there is anything else I should change just let me know.

P.S.: I accidentally also commited a fix for windows where for me the generated fontlist.txt was always empty as the dispatched goroutine wasn't fast enough to lock the  mutex. Hope it is fine to leave in, otherwise I will move it out.